### PR TITLE
Bump gson version and remove duplicating in each operation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.code.gson:gson:2.8.0'
+    compile 'com.google.code.gson:gson:2.8.5'
     testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/java/com/tananaev/jsonpatch/JsonPatch.java
+++ b/src/main/java/com/tananaev/jsonpatch/JsonPatch.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
 public class JsonPatch extends LinkedList<AbsOperation> {
 
     public JsonElement apply(JsonElement original) {
-        JsonElement result = original;
+        JsonElement result = original.deepCopy();
         for ( AbsOperation operation: this){
             result = operation.apply(result);
         }

--- a/src/main/java/com/tananaev/jsonpatch/JsonPatch.java
+++ b/src/main/java/com/tananaev/jsonpatch/JsonPatch.java
@@ -20,6 +20,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.tananaev.jsonpatch.gson.JsonPathSerializer;
 import com.tananaev.jsonpatch.operation.AbsOperation;
+import com.tananaev.jsonpatch.operation.InPlaceElementWrapper;
 
 import java.util.LinkedList;
 
@@ -27,10 +28,11 @@ public class JsonPatch extends LinkedList<AbsOperation> {
 
     public JsonElement apply(JsonElement original) {
         JsonElement result = original.deepCopy();
+        InPlaceElementWrapper inPlaceElement = new InPlaceElementWrapper(result);
         for ( AbsOperation operation: this){
-            result = operation.apply(result);
+            operation.applyInPlace(inPlaceElement);
         }
-        return result;
+        return inPlaceElement.getJsonElement();
     }
 
     @Override

--- a/src/main/java/com/tananaev/jsonpatch/operation/AbsOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/AbsOperation.java
@@ -1,7 +1,6 @@
 package com.tananaev.jsonpatch.operation;
 
 import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
 import com.tananaev.jsonpatch.JsonPath;
 
@@ -18,10 +17,24 @@ public abstract class AbsOperation {
 
     public abstract String getOperationName();
 
-    public abstract JsonElement apply( JsonElement original );
+    /**
+     * Applies the operation on the source and returns the patched object. The source is unmodified.
+     * @param sourceElement to which the patch is to be applied
+     * @return final json after patch is applied
+     */
+    public JsonElement apply( JsonElement sourceElement ){
+        JsonElement copiedSource = sourceElement.deepCopy();
+        InPlaceElementWrapper inPlaceElement = new InPlaceElementWrapper(copiedSource);
+        applyInPlace(inPlaceElement);
+        return inPlaceElement.getJsonElement();
+    };
 
-    protected JsonElement duplicate(JsonElement original) {
-        return new JsonParser().parse(original.toString());
-    }
+    /**
+     * An optimised version of apply where the source is not copied and is directly modified if possible.
+     * Updates the inPlaceElement to contain the patched json element.
+     * Refer to {@link InPlaceElementWrapper} for details on why a wrapper is needed
+     * @param inPlaceElement input to which the patch is to be applied
+     */
+    public abstract void applyInPlace(InPlaceElementWrapper inPlaceElement );
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/AddOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/AddOperation.java
@@ -26,9 +26,8 @@ public class AddOperation extends AbsOperation {
 
     @Override
     public JsonElement apply(JsonElement original) {
-        JsonElement result = duplicate( original );
 
-        JsonElement item = path.head().navigate(result);
+        JsonElement item = path.head().navigate(original);
 
         if ( item.isJsonObject() ){
             item.getAsJsonObject().add(path.tail(),data);
@@ -55,7 +54,7 @@ public class AddOperation extends AbsOperation {
 
         }
 
-        return result;
+        return original;
     }
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/AddOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/AddOperation.java
@@ -25,9 +25,9 @@ public class AddOperation extends AbsOperation {
     }
 
     @Override
-    public JsonElement apply(JsonElement original) {
-
-        JsonElement item = path.head().navigate(original);
+    public void applyInPlace(InPlaceElementWrapper inPlaceElement){
+        JsonElement sourceElement = inPlaceElement.getJsonElement();
+        JsonElement item = path.head().navigate(sourceElement);
 
         if ( item.isJsonObject() ){
             item.getAsJsonObject().add(path.tail(),data);
@@ -53,8 +53,6 @@ public class AddOperation extends AbsOperation {
             }
 
         }
-
-        return original;
     }
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/InPlaceElementWrapper.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/InPlaceElementWrapper.java
@@ -1,0 +1,26 @@
+package com.tananaev.jsonpatch.operation;
+
+import com.google.gson.JsonElement;
+
+/**
+ * Wrapper class over json element to pass as an input for in place operations.
+ * This is needed because we cannot convert actual JsonElement types into another in place
+ * i.e, we cannot convert a JsonPrimitive (or other) into a JsonObject (or other) in-place
+ * if needed by the patch operation.
+ */
+public class InPlaceElementWrapper {
+
+    private JsonElement jsonElement;
+
+    public JsonElement getJsonElement() {
+        return jsonElement;
+    }
+
+    public InPlaceElementWrapper(JsonElement element) {
+        this.jsonElement = element;
+    }
+
+    public void setJsonElement(JsonElement jsonElement) {
+        this.jsonElement = jsonElement;
+    }
+}

--- a/src/main/java/com/tananaev/jsonpatch/operation/MoveOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/MoveOperation.java
@@ -24,12 +24,11 @@ public class MoveOperation extends AbsOperation{
 
     @Override
     public JsonElement apply(JsonElement original) {
-        JsonElement result = duplicate( original );
 
-        JsonElement value = from.navigate(result);
+        JsonElement value = from.navigate(original);
 
-        JsonElement source = from.head().navigate(result);
-        JsonElement destination = path.head().navigate(result);
+        JsonElement source = from.head().navigate(original);
+        JsonElement destination = path.head().navigate(original);
 
         if ( source.isJsonObject() ){
             source.getAsJsonObject().remove(from.tail());
@@ -65,7 +64,7 @@ public class MoveOperation extends AbsOperation{
             }
         }
 
-        return result;
+        return original;
     }
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/MoveOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/MoveOperation.java
@@ -23,17 +23,17 @@ public class MoveOperation extends AbsOperation{
     }
 
     @Override
-    public JsonElement apply(JsonElement original) {
+    public void applyInPlace(InPlaceElementWrapper inPlaceElement) {
+        JsonElement sourceElement = inPlaceElement.getJsonElement();
+        JsonElement value = from.navigate(sourceElement);
 
-        JsonElement value = from.navigate(original);
+        JsonElement existingElement = from.head().navigate(sourceElement);
+        JsonElement destination = path.head().navigate(sourceElement);
 
-        JsonElement source = from.head().navigate(original);
-        JsonElement destination = path.head().navigate(original);
-
-        if ( source.isJsonObject() ){
-            source.getAsJsonObject().remove(from.tail());
-        } else if ( source.isJsonArray() ){
-            JsonArray array = source.getAsJsonArray();
+        if ( existingElement.isJsonObject() ){
+            existingElement.getAsJsonObject().remove(from.tail());
+        } else if ( existingElement.isJsonArray() ){
+            JsonArray array = existingElement.getAsJsonArray();
 
             int index = (from.tail().equals("-")) ? array.size() : Integer.valueOf(from.tail());
 
@@ -63,8 +63,6 @@ public class MoveOperation extends AbsOperation{
                 array.add(stuff);
             }
         }
-
-        return original;
     }
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/RemoveOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/RemoveOperation.java
@@ -17,9 +17,8 @@ public class RemoveOperation extends AbsOperation{
 
     @Override
     public JsonElement apply(JsonElement original) {
-        JsonElement result = duplicate( original );
 
-        JsonElement item = path.head().navigate(result);
+        JsonElement item = path.head().navigate(original);
 
         if ( item.isJsonObject() ){
             item.getAsJsonObject().remove(path.tail());
@@ -31,7 +30,7 @@ public class RemoveOperation extends AbsOperation{
             array.remove(index);
         }
 
-        return result;
+        return original;
     }
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/RemoveOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/RemoveOperation.java
@@ -16,9 +16,9 @@ public class RemoveOperation extends AbsOperation{
     }
 
     @Override
-    public JsonElement apply(JsonElement original) {
+    public void applyInPlace(InPlaceElementWrapper inPlaceElement) {
 
-        JsonElement item = path.head().navigate(original);
+        JsonElement item = path.head().navigate(inPlaceElement.getJsonElement());
 
         if ( item.isJsonObject() ){
             item.getAsJsonObject().remove(path.tail());
@@ -30,7 +30,6 @@ public class RemoveOperation extends AbsOperation{
             array.remove(index);
         }
 
-        return original;
     }
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/ReplaceOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/ReplaceOperation.java
@@ -23,9 +23,8 @@ public class ReplaceOperation extends AbsOperation {
 
     @Override
     public JsonElement apply(JsonElement original) {
-        JsonElement result = duplicate( original );
 
-        JsonElement item = path.head().navigate(result);
+        JsonElement item = path.head().navigate(original);
 
         if ( item.isJsonObject() ){
             JsonObject object = item.getAsJsonObject();
@@ -48,7 +47,7 @@ public class ReplaceOperation extends AbsOperation {
             return data;
         }
 
-        return result;
+        return original;
     }
 
 }

--- a/src/main/java/com/tananaev/jsonpatch/operation/ReplaceOperation.java
+++ b/src/main/java/com/tananaev/jsonpatch/operation/ReplaceOperation.java
@@ -22,9 +22,9 @@ public class ReplaceOperation extends AbsOperation {
     }
 
     @Override
-    public JsonElement apply(JsonElement original) {
+    public void applyInPlace(InPlaceElementWrapper inPlaceElement) {
 
-        JsonElement item = path.head().navigate(original);
+        JsonElement item = path.head().navigate(inPlaceElement.getJsonElement());
 
         if ( item.isJsonObject() ){
             JsonObject object = item.getAsJsonObject();
@@ -44,10 +44,9 @@ public class ReplaceOperation extends AbsOperation {
             }
 
         } else {
-            return data;
+            inPlaceElement.setJsonElement(data);
         }
 
-        return original;
     }
 
 }

--- a/src/test/java/com/tananaev/jsonpatch/test/OperationTest.java
+++ b/src/test/java/com/tananaev/jsonpatch/test/OperationTest.java
@@ -22,20 +22,13 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.tananaev.jsonpatch.JsonPath;
 import com.tananaev.jsonpatch.operation.AddOperation;
+import com.tananaev.jsonpatch.operation.InPlaceElementWrapper;
 import com.tananaev.jsonpatch.operation.ReplaceOperation;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class OperationTest {
 
-    @Test
-    public void basicAddWorks(){
-        JsonElement element = new JsonObject();
-
-        JsonElement result = new AddOperation(new JsonPath("/a"), new JsonObject() ).apply(element);
-
-        Assert.assertEquals("{\"a\":{}}", result.toString());
-    }
 
     @Test
     public void replaceRootNullWithPrimitive(){

--- a/src/test/java/com/tananaev/jsonpatch/test/operation/AddOperationTest.java
+++ b/src/test/java/com/tananaev/jsonpatch/test/operation/AddOperationTest.java
@@ -1,0 +1,35 @@
+package com.tananaev.jsonpatch.test.operation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.tananaev.jsonpatch.JsonPath;
+import com.tananaev.jsonpatch.operation.AddOperation;
+import com.tananaev.jsonpatch.operation.InPlaceElementWrapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AddOperationTest {
+
+    @Test
+    public void basicAddWorks(){
+        JsonElement element = new JsonObject();
+        String originalData = element.toString();
+
+        JsonElement result = new AddOperation(new JsonPath("/a"), new JsonObject() ).apply(element);
+
+        Assert.assertEquals(originalData, element.toString());
+        Assert.assertEquals("{\"a\":{}}", result.toString());
+    }
+
+    @Test
+    public void basicInPlaceAddWorks(){
+        JsonElement element = new JsonObject();
+        InPlaceElementWrapper inPlaceElement = new InPlaceElementWrapper(element);
+        AddOperation addOperation = new AddOperation(new JsonPath("/a"), new JsonObject());
+
+        addOperation.applyInPlace(inPlaceElement);
+        JsonElement result = inPlaceElement.getJsonElement();
+
+        Assert.assertEquals("{\"a\":{}}", result.toString());
+    }
+}

--- a/src/test/java/com/tananaev/jsonpatch/test/operation/MoveOperationTest.java
+++ b/src/test/java/com/tananaev/jsonpatch/test/operation/MoveOperationTest.java
@@ -1,0 +1,40 @@
+package com.tananaev.jsonpatch.test.operation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.tananaev.jsonpatch.JsonPath;
+import com.tananaev.jsonpatch.operation.AddOperation;
+import com.tananaev.jsonpatch.operation.InPlaceElementWrapper;
+import com.tananaev.jsonpatch.operation.MoveOperation;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MoveOperationTest {
+
+    @Test
+    public void basicMoveWorks(){
+        JsonElement element = new JsonObject();
+        element.getAsJsonObject().add("a", new JsonPrimitive("123"));
+        String originalData = element.toString();
+
+        JsonElement result = new MoveOperation(new JsonPath("/a"), new JsonPath("/b") ).apply(element);
+
+        Assert.assertEquals(originalData, element.toString());
+        Assert.assertEquals("{\"b\":\"123\"}", result.toString());
+    }
+
+    @Test
+    public void basicInPlaceMoveWorks(){
+
+        JsonElement element = new JsonObject();
+        element.getAsJsonObject().add("a", new JsonPrimitive("123"));
+        InPlaceElementWrapper inPlaceElement = new InPlaceElementWrapper(element);
+
+        MoveOperation moveOperation = new MoveOperation(new JsonPath("/a"), new JsonPath("/b") );
+        moveOperation.applyInPlace(inPlaceElement);
+
+        Assert.assertEquals("{\"b\":\"123\"}", inPlaceElement.getJsonElement().toString());
+
+    }
+}

--- a/src/test/java/com/tananaev/jsonpatch/test/operation/RemoveOperationTest.java
+++ b/src/test/java/com/tananaev/jsonpatch/test/operation/RemoveOperationTest.java
@@ -1,0 +1,40 @@
+package com.tananaev.jsonpatch.test.operation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.tananaev.jsonpatch.JsonPath;
+import com.tananaev.jsonpatch.operation.InPlaceElementWrapper;
+import com.tananaev.jsonpatch.operation.MoveOperation;
+import com.tananaev.jsonpatch.operation.RemoveOperation;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RemoveOperationTest {
+
+    @Test
+    public void basicRemoveWorks(){
+        JsonElement element = new JsonObject();
+        element.getAsJsonObject().add("a", new JsonPrimitive("123"));
+        String originalData = element.toString();
+
+        JsonElement result = new RemoveOperation(new JsonPath("/a") ).apply(element);
+
+        Assert.assertEquals(originalData, element.toString());
+        Assert.assertEquals("{}", result.toString());
+    }
+
+    @Test
+    public void basicInPlaceRemoveWorks(){
+
+        JsonElement element = new JsonObject();
+        element.getAsJsonObject().add("a", new JsonPrimitive("123"));
+        InPlaceElementWrapper inPlaceElement = new InPlaceElementWrapper(element);
+
+        RemoveOperation removeOperation = new RemoveOperation(new JsonPath("/a"));
+        removeOperation.applyInPlace(inPlaceElement);
+
+        Assert.assertEquals("{}", inPlaceElement.getJsonElement().toString());
+
+    }
+}

--- a/src/test/java/com/tananaev/jsonpatch/test/operation/ReplaceOperationTest.java
+++ b/src/test/java/com/tananaev/jsonpatch/test/operation/ReplaceOperationTest.java
@@ -1,0 +1,43 @@
+package com.tananaev.jsonpatch.test.operation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.tananaev.jsonpatch.JsonPath;
+import com.tananaev.jsonpatch.operation.InPlaceElementWrapper;
+import com.tananaev.jsonpatch.operation.RemoveOperation;
+import com.tananaev.jsonpatch.operation.ReplaceOperation;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReplaceOperationTest {
+    @Test
+    public void basicReplaceWorks(){
+        JsonElement element = new JsonObject();
+        element.getAsJsonObject().add("a", new JsonPrimitive("123"));
+        String originalData = element.toString();
+
+        JsonElement newElement = new JsonPrimitive("1234");
+
+        JsonElement result = new ReplaceOperation(new JsonPath("/a"), newElement).apply(element);
+
+        Assert.assertEquals(originalData, element.toString());
+        Assert.assertEquals("{\"a\":\"1234\"}", result.toString());
+    }
+
+    @Test
+    public void basicInPlaceReplaceWorks(){
+
+        JsonElement element = new JsonObject();
+        element.getAsJsonObject().add("a", new JsonPrimitive("123"));
+
+        JsonElement newElement = new JsonPrimitive("1234");
+        InPlaceElementWrapper inPlaceElement = new InPlaceElementWrapper(element);
+
+        ReplaceOperation replaceOperation = new ReplaceOperation(new JsonPath("/a"), newElement);
+        replaceOperation.applyInPlace(inPlaceElement);
+
+        Assert.assertEquals("{\"a\":\"1234\"}", inPlaceElement.getJsonElement().toString());
+
+    }
+}


### PR DESCRIPTION
We are currently copying the data each time.
Created an _ApplyInPlace_ which modifies the input without copying the data. To maintain backward compatibility for anyone using _Apply_ function directly from the operations, both _apply_ and _applyInPlace_ are exposed by _AbsOperation_
The patch now uses applyInPlace to calculate the final result so that we save on processing time.

**Perf Analysis:**
Tested with source and diff payload sizes of around 15KB applying the patch 10k times.

**Existing solution** (average over 5 runs): 6826.5 ms
**New InPlace solution** (average over 5 runs): 191.5 ms
